### PR TITLE
Feat/command gripper via topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A ROS2 package for use with the Robotiq 2-Finger 140mm gripper.
 ## Overview
 
 The repo contains four ROS2 packages (detailed description below):
+
 | Package Name | Description |
 | --- | --- |
 | robotiq_2f_gripper_description | A description package containing the URDF and meshes of the gripper to be viewed in RViz  |
@@ -74,6 +75,35 @@ Listen to the current gripper state. The gripper state here is defined as a bool
 ros2 topic echo /robotiq_2f_gripper/object_grasped
 ```
 
+#### Controlling the Gripper via Topic Subscribers
+
+In addition to the action server, the gripper can also be controlled by publishing to the following topics:
+
+##### Confidence-based Control
+
+You can control the gripper by publishing confidence values between -1.0 and 1.0 to the confidence command topic:
+
+```bash
+ros2 topic pub /robotiq_2f_gripper/confidence_command std_msgs/msg/Float32MultiArray "data: [0.8]"  # Open with high confidence
+ros2 topic pub /robotiq_2f_gripper/confidence_command std_msgs/msg/Float32MultiArray "data: [-0.8]"  # Close with high confidence
+ros2 topic pub /robotiq_2f_gripper/confidence_command std_msgs/msg/Float32MultiArray "data: [0.0]"  # Neutral confidence
+```
+
+This command mode uses hysteresis to avoid oscillation:
+
+- Values > 0.2: Opens the gripper fully
+- Values < -0.2: Closes the gripper fully
+- Values between -0.2 and 0.2: Maintains current state (hysteresis band)
+
+##### Binary Control
+
+For direct binary control without hysteresis, publish exactly 1.0 (open) or -1.0 (close) to the binary command topic:
+
+```bash
+ros2 topic pub /robotiq_2f_gripper/binary_command std_msgs/msg/Float32MultiArray "data: [1.0]"  # Open
+ros2 topic pub /robotiq_2f_gripper/binary_command std_msgs/msg/Float32MultiArray "data: [-1.0]"  # Close
+```
+
 #### Launch Arguments when Starting the Hardware
 
 *fake_hardware* (default: false)
@@ -112,19 +142,18 @@ This package should not be run or launched. Instead it provides the driver code 
 
 This package should not be run or launched. Instead it provides a message template for the communication with the gripper.
 
-
 ## Troubleshooting
 
 1. When launching the gripper:
 
-```
+```bash
 ros2 launch robotiq_2f_gripper_hardware robotiq_2f_gripper_launch.py serial_port:=/dev/ttyUSB0
 
 ```
 
 and you receive:
 
-```
+```bash
 [robotiq_2f_gripper_node-1] terminate called after throwing an instance of 'serial::IOException'
 [robotiq_2f_gripper_node-1]   what():  IO Exception (2): No such file or directory, file /home/jannis.haberhausen/GitHub/robotiq_2f_gripper_ros2/src/serial-ros2/src/impl/unix.cc, line 152.
 ```
@@ -133,14 +162,18 @@ Fix: connect the USB of the robotiq gripper.
 
 2. When sending an action to the gripper action server:
 
-```
+```bash
 ros2 action send_goal /robotiq_2f_gripper_action robotiq_2f_gripper_msgs/action/MoveTwoFingerGripper "{target_position: 0.05, target_speed: 0.1, target_force: 0.1}"
 ```
 
 and you receive:
 
-```
+```bash
 The passed action type is invalid
 ```
 
-Fix: source your workspace in the new terminal ```source install/setup.bash```
+Fix: source your workspace in the new terminal
+
+```bash
+source install/setup.bash
+```

--- a/robotiq_2f_gripper_hardware/include/robotiq_2f_gripper_hardware/robotiq_2f_gripper_node.hpp
+++ b/robotiq_2f_gripper_hardware/include/robotiq_2f_gripper_hardware/robotiq_2f_gripper_node.hpp
@@ -50,6 +50,7 @@ namespace robotiq_2f_gripper_hardware
         rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr joint_state_publisher_;
         rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr gripper_state_publisher_;
         rclcpp::Subscription<std_msgs::msg::Float32MultiArray>::SharedPtr gripper_command_subscriber_;
+        rclcpp::Subscription<std_msgs::msg::Float32MultiArray>::SharedPtr gripper_binary_command_subscriber_;
 
         std::atomic<bool> running_{false};
         sensor_msgs::msg::JointState joint_state_;
@@ -65,6 +66,7 @@ namespace robotiq_2f_gripper_hardware
         void update_joint_state_callback();
         void update_gripper_state_callback();
         void gripper_command_callback(const std_msgs::msg::Float32MultiArray::SharedPtr msg);
+        void gripper_binary_command_callback(const std_msgs::msg::Float32MultiArray::SharedPtr msg);
 
         uint8_t decimalToHex(int value);
         int convertToGripperSystemPosition(double position);

--- a/robotiq_2f_gripper_hardware/include/robotiq_2f_gripper_hardware/robotiq_2f_gripper_node.hpp
+++ b/robotiq_2f_gripper_hardware/include/robotiq_2f_gripper_hardware/robotiq_2f_gripper_node.hpp
@@ -5,21 +5,24 @@
 #include <rclcpp_action/rclcpp_action.hpp>
 #include <sensor_msgs/msg/joint_state.hpp>
 #include <std_msgs/msg/bool.hpp>
+#include <std_msgs/msg/float32_multi_array.hpp>
 #include <thread>
 
 #include <robotiq_2f_gripper_msgs/action/move_two_finger_gripper.hpp>
 
-namespace robotiq_2f_gripper_hardware {
+namespace robotiq_2f_gripper_hardware
+{
 
-using SetPosition = robotiq_2f_gripper_msgs::action::MoveTwoFingerGripper;
-using robotiq_2f_gripper_interfaces::DefaultDriver;
-using robotiq_2f_gripper_interfaces::DefaultSerial;
+    using SetPosition = robotiq_2f_gripper_msgs::action::MoveTwoFingerGripper;
+    using robotiq_2f_gripper_interfaces::DefaultDriver;
+    using robotiq_2f_gripper_interfaces::DefaultSerial;
 
-class GripperNode : public rclcpp::Node {
+    class GripperNode : public rclcpp::Node
+    {
     public:
         GripperNode();
         ~GripperNode();
-    
+
     private:
         std::string serial_port_;
         int baudrate_;
@@ -30,8 +33,8 @@ class GripperNode : public rclcpp::Node {
         std::unique_ptr<DefaultDriver> driver_;
 
         const double MAX_GRIPPER_POSITION_METER = 0.142; // distance between fingers in meters
-        const int FULLY_CLOSED_THRESHOLD = 226; // gripper position value (from hexadecimal gripper system interpreted as int) when first fully closed (226 to 255 is fully closed) 
-        const double MAX_GRIPPER_POSITION_RAD = 0.7; // upper limit of the gripper in radians (0.7 is fully closed)
+        const int FULLY_CLOSED_THRESHOLD = 226;          // gripper position value (from hexadecimal gripper system interpreted as int) when first fully closed (226 to 255 is fully closed)
+        const double MAX_GRIPPER_POSITION_RAD = 0.7;     // upper limit of the gripper in radians (0.7 is fully closed)
 
         double gripper_position_;
         double gripper_speed_;
@@ -40,13 +43,14 @@ class GripperNode : public rclcpp::Node {
         rclcpp_action::Server<SetPosition>::SharedPtr action_server_;
         rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr joint_state_publisher_;
         rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr gripper_state_publisher_;
+        rclcpp::Subscription<std_msgs::msg::Float32MultiArray>::SharedPtr gripper_command_subscriber_;
 
         std::atomic<bool> running_{false};
         sensor_msgs::msg::JointState joint_state_;
         rclcpp::TimerBase::SharedPtr timer_1_, timer_2_;
 
         rclcpp_action::GoalResponse handle_move_goal(
-            const rclcpp_action::GoalUUID& /*uuid*/,
+            const rclcpp_action::GoalUUID & /*uuid*/,
             std::shared_ptr<const SetPosition::Goal> goal);
         rclcpp_action::CancelResponse handle_cancel_move(
             const std::shared_ptr<rclcpp_action::ServerGoalHandle<SetPosition>> /*goal_handle*/);
@@ -54,11 +58,12 @@ class GripperNode : public rclcpp::Node {
         void execute(const std::shared_ptr<rclcpp_action::ServerGoalHandle<SetPosition>> goal_handle);
         void update_joint_state_callback();
         void update_gripper_state_callback();
+        void gripper_command_callback(const std_msgs::msg::Float32MultiArray::SharedPtr msg);
 
         uint8_t decimalToHex(int value);
         int convertToGripperSystemPosition(double position);
         double convertToMillimeters(int value);
         int convertToGripperSystem(double value);
-};
+    };
 
-}  // namespace robotiq_2f_gripper_hardware
+} // namespace robotiq_2f_gripper_hardware

--- a/robotiq_2f_gripper_hardware/include/robotiq_2f_gripper_hardware/robotiq_2f_gripper_node.hpp
+++ b/robotiq_2f_gripper_hardware/include/robotiq_2f_gripper_hardware/robotiq_2f_gripper_node.hpp
@@ -40,6 +40,12 @@ namespace robotiq_2f_gripper_hardware
         double gripper_speed_;
         double gripper_force_;
 
+        // Variables for confidence-based control with hysteresis
+        double previous_confidence_{0.0};
+        bool initial_command_{true};
+        const double OPEN_THRESHOLD{0.2};
+        const double CLOSE_THRESHOLD{-0.2};
+
         rclcpp_action::Server<SetPosition>::SharedPtr action_server_;
         rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr joint_state_publisher_;
         rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr gripper_state_publisher_;

--- a/robotiq_2f_gripper_hardware/src/robotiq_2f_gripper_node.cpp
+++ b/robotiq_2f_gripper_hardware/src/robotiq_2f_gripper_node.cpp
@@ -344,72 +344,114 @@ void GripperNode::gripper_command_callback(const std_msgs::msg::Float32MultiArra
 
     if (msg->data.size() < 1)
     {
-        RCLCPP_ERROR(get_logger(), "Received empty command array. Expected at least position data.");
+        RCLCPP_ERROR(get_logger(), "Received empty command array. Expected a confidence value.");
         return;
     }
 
-    double position = msg->data[0];
-    double speed = (msg->data.size() > 1) ? msg->data[1] : 0.5; // Default speed 0.5
-    double force = (msg->data.size() > 2) ? msg->data[2] : 0.5; // Default force 0.5
+    // Get the confidence value from the message
+    double confidence = msg->data[0];
 
-    // Validate inputs
-    if (position < 0 || position > 0.142)
+    // Validate input range
+    if (confidence < -1.0 || confidence > 1.0)
     {
-        RCLCPP_ERROR(get_logger(), "Invalid position value: %f. Must be between 0 (fully closed) and 0.142 (fully open)", position);
-        return;
-    }
-    if (speed < 0 || speed > 1)
-    {
-        RCLCPP_ERROR(get_logger(), "Invalid speed value: %f. Must be between 0 and 1", speed);
-        return;
-    }
-    if (force < 0 || force > 1)
-    {
-        RCLCPP_ERROR(get_logger(), "Invalid force value: %f. Must be between 0 and 1", force);
+        RCLCPP_ERROR(get_logger(), "Invalid confidence value: %f. Must be between -1.0 and 1.0", confidence);
         return;
     }
 
-    RCLCPP_INFO(get_logger(), "Received gripper command: position=%f, speed=%f, force=%f", position, speed, force);
+    // Using class member variables for hysteresis thresholds and state tracking
 
-    running_ = true;
+    // Default speed and force for the gripper
+    double speed = 0.5; // Default speed 0.5
+    double force = 0.5; // Default force 0.5
 
-    if (fake_hardware_)
+    // Calculate gripper position based on confidence with hysteresis
+    double position;
+
+    // If it's the first command or if confidence crosses thresholds
+    if (initial_command_ ||
+        (confidence > OPEN_THRESHOLD && previous_confidence_ <= OPEN_THRESHOLD) ||
+        (confidence < CLOSE_THRESHOLD && previous_confidence_ >= CLOSE_THRESHOLD))
     {
-        gripper_position_ = position;
-        gripper_speed_ = speed;
-        gripper_force_ = force;
-        RCLCPP_INFO(get_logger(), "[Fake Hardware] Gripper position set to %f", position);
-        running_ = false;
-        return;
-    }
-
-    try
-    {
-        driver_->set_force(convertToGripperSystem(force));
-        driver_->set_speed(convertToGripperSystem(speed));
-        driver_->set_gripper_position(convertToGripperSystemPosition(position));
-
-        auto start_time = std::chrono::steady_clock::now();
-        auto timeout = std::chrono::seconds(action_timeout_);
-        while (std::chrono::steady_clock::now() - start_time < timeout)
+        // Determine position based on confidence
+        if (confidence > OPEN_THRESHOLD)
         {
-            if (!driver_->gripper_is_moving())
+            position = MAX_GRIPPER_POSITION_METER; // Fully open (0.142m)
+            RCLCPP_INFO(get_logger(), "Confidence value %f exceeds open threshold, opening gripper", confidence);
+        }
+        else if (confidence < CLOSE_THRESHOLD)
+        {
+            position = 0.0; // Fully closed
+            RCLCPP_INFO(get_logger(), "Confidence value %f below close threshold, closing gripper", confidence);
+        }
+        else
+        {
+            // In the deadband - keep previous state if not the first command
+            if (initial_command_)
             {
-                RCLCPP_INFO(get_logger(), "Gripper movement completed.");
-                running_ = false;
+                position = MAX_GRIPPER_POSITION_METER / 2.0; // Middle position for first command
+                RCLCPP_INFO(get_logger(), "Initial confidence in deadband %f, setting to middle position", confidence);
+            }
+            else
+            {
+                // No change due to hysteresis
+                previous_confidence_ = confidence;
+                RCLCPP_INFO(get_logger(), "Confidence value %f in hysteresis zone, maintaining current state", confidence);
                 return;
             }
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }
 
-        RCLCPP_INFO(get_logger(), "Gripper movement timed out.");
-    }
-    catch (const std::runtime_error &e)
-    {
-        RCLCPP_ERROR(get_logger(), "Error executing command: %s", e.what());
-    }
+        RCLCPP_INFO(get_logger(), "Setting gripper position to %f based on confidence %f", position, confidence);
 
-    running_ = false;
+        // Remember for hysteresis
+        previous_confidence_ = confidence;
+        initial_command_ = false;
+
+        running_ = true;
+
+        if (fake_hardware_)
+        {
+            gripper_position_ = position;
+            gripper_speed_ = speed;
+            gripper_force_ = force;
+            RCLCPP_INFO(get_logger(), "[Fake Hardware] Gripper position set to %f", position);
+            running_ = false;
+            return;
+        }
+
+        try
+        {
+            driver_->set_force(convertToGripperSystem(force));
+            driver_->set_speed(convertToGripperSystem(speed));
+            driver_->set_gripper_position(convertToGripperSystemPosition(position));
+
+            auto start_time = std::chrono::steady_clock::now();
+            auto timeout = std::chrono::seconds(action_timeout_);
+            while (std::chrono::steady_clock::now() - start_time < timeout)
+            {
+                if (!driver_->gripper_is_moving())
+                {
+                    RCLCPP_INFO(get_logger(), "Gripper movement completed.");
+                    running_ = false;
+                    return;
+                }
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            }
+
+            RCLCPP_INFO(get_logger(), "Gripper movement timed out.");
+        }
+        catch (const std::runtime_error &e)
+        {
+            RCLCPP_ERROR(get_logger(), "Error executing command: %s", e.what());
+        }
+
+        running_ = false;
+    }
+    else
+    {
+        // Update previous confidence but don't send new command (within hysteresis band)
+        previous_confidence_ = confidence;
+        RCLCPP_DEBUG(get_logger(), "Confidence value %f within hysteresis zone, no action taken", confidence);
+    }
 }
 
 int main(int argc, char **argv)

--- a/robotiq_2f_gripper_hardware/src/robotiq_2f_gripper_node.cpp
+++ b/robotiq_2f_gripper_hardware/src/robotiq_2f_gripper_node.cpp
@@ -17,8 +17,8 @@ using namespace std::placeholders;
 using robotiq_2f_gripper_interfaces::DefaultDriver;
 using robotiq_2f_gripper_interfaces::DefaultSerial;
 
-
-GripperNode::GripperNode() : Node("robotiq_2f_gripper_node") {
+GripperNode::GripperNode() : Node("robotiq_2f_gripper_node")
+{
     declare_parameter<std::string>("serial_port");
     serial_port_ = get_parameter("serial_port").as_string();
     RCLCPP_INFO(get_logger(), "Using serial port: %s", serial_port_.c_str());
@@ -43,7 +43,8 @@ GripperNode::GripperNode() : Node("robotiq_2f_gripper_node") {
     fake_hardware_ = get_parameter("fake_hardware").as_bool();
     RCLCPP_INFO(get_logger(), "Using fake hardware: %s", fake_hardware_ ? "true" : "false");
 
-    if (!fake_hardware_) {
+    if (!fake_hardware_)
+    {
         auto serial = std::make_unique<DefaultSerial>();
         serial->set_port(serial_port_);
         serial->set_baudrate(baudrate_);
@@ -82,44 +83,58 @@ GripperNode::GripperNode() : Node("robotiq_2f_gripper_node") {
     timer_2_ = create_wall_timer(
         std::chrono::milliseconds(50), std::bind(&GripperNode::update_gripper_state_callback, this));
 
+    // Create subscriber for Float32MultiArray to command the gripper
+    gripper_command_subscriber_ = create_subscription<std_msgs::msg::Float32MultiArray>(
+        "robotiq_2f_gripper/command", 10,
+        std::bind(&GripperNode::gripper_command_callback, this, _1));
+    RCLCPP_INFO(get_logger(), "Gripper command subscriber created");
+
     RCLCPP_INFO(get_logger(), "Gripper node initialized");
 }
 
-GripperNode::~GripperNode() {
-    if (!fake_hardware_) {
+GripperNode::~GripperNode()
+{
+    if (!fake_hardware_)
+    {
         driver_->deactivate();
         driver_->disconnect();
     }
 }
 
 rclcpp_action::GoalResponse GripperNode::handle_move_goal(
-    const rclcpp_action::GoalUUID& /*uuid*/,
+    const rclcpp_action::GoalUUID & /*uuid*/,
     std::shared_ptr<const SetPosition::Goal> goal)
 {
     RCLCPP_INFO(get_logger(), "Received goal request with %f meters", goal->target_position);
 
-    if (running_) {
+    if (running_)
+    {
         RCLCPP_WARN(get_logger(), "Discarding new goal request, previous goal still running");
         return rclcpp_action::GoalResponse::REJECT;
     }
 
-    if (!fake_hardware_) {
-        if (!driver_->is_gripper_active()) {
+    if (!fake_hardware_)
+    {
+        if (!driver_->is_gripper_active())
+        {
             RCLCPP_ERROR(get_logger(), "Gripper is not activated");
             return rclcpp_action::GoalResponse::REJECT;
         }
     }
 
     // Check if the goal is valid
-    if (goal->target_position < 0 || goal->target_position > 0.142) {
+    if (goal->target_position < 0 || goal->target_position > 0.142)
+    {
         RCLCPP_ERROR(get_logger(), "Invalid goal request, target position (in meters [m]) must be between 0 (fully closed) and 0.14 (fully open)");
         return rclcpp_action::GoalResponse::REJECT;
     }
-    if (goal->target_speed < 0 || goal->target_speed > 1) {
+    if (goal->target_speed < 0 || goal->target_speed > 1)
+    {
         RCLCPP_ERROR(get_logger(), "Invalid goal request, target speed must be between 0 and 1");
         return rclcpp_action::GoalResponse::REJECT;
     }
-    if (goal->target_force < 0 || goal->target_force > 1) {
+    if (goal->target_force < 0 || goal->target_force > 1)
+    {
         RCLCPP_ERROR(get_logger(), "Invalid goal request, target force must be between 0 and 1");
         return rclcpp_action::GoalResponse::REJECT;
     }
@@ -151,7 +166,8 @@ void GripperNode::execute(
     auto feedback = std::make_shared<SetPosition::Feedback>();
     auto result = std::make_shared<SetPosition::Result>();
 
-    if (fake_hardware_) {
+    if (fake_hardware_)
+    {
         gripper_position_ = goal->target_position;
         gripper_speed_ = 0;
         gripper_force_ = goal->target_force;
@@ -163,7 +179,8 @@ void GripperNode::execute(
         return;
     }
 
-    try {
+    try
+    {
         feedback->feedback = "Setting force";
         goal_handle->publish_feedback(feedback);
         driver_->set_force(convertToGripperSystem(goal->target_force));
@@ -189,13 +206,15 @@ void GripperNode::execute(
                 running_ = false;
                 return;
             }
-            
+
             // provide feedback about ongoing movement
             feedback->feedback = "Gripper is moving";
             goal_handle->publish_feedback(feedback);
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }
-    } catch (const std::runtime_error& e) {
+    }
+    catch (const std::runtime_error &e)
+    {
         RCLCPP_ERROR(get_logger(), "Error executing goal: %s", e.what());
         result->success = false;
         goal_handle->abort(result);
@@ -208,66 +227,79 @@ void GripperNode::execute(
     running_ = false;
 }
 
-void GripperNode::update_joint_state_callback() {
-    if (running_) {
+void GripperNode::update_joint_state_callback()
+{
+    if (running_)
+    {
         return;
     }
 
     double curr_gripper_position;
     double curr_gripper_position_rad;
-    if (!fake_hardware_) {
+    if (!fake_hardware_)
+    {
         curr_gripper_position = static_cast<int>(driver_->get_gripper_position());
-        if (curr_gripper_position > FULLY_CLOSED_THRESHOLD) {
+        if (curr_gripper_position > FULLY_CLOSED_THRESHOLD)
+        {
             curr_gripper_position_rad = MAX_GRIPPER_POSITION_RAD;
-        } else {
+        }
+        else
+        {
             curr_gripper_position_rad = curr_gripper_position / FULLY_CLOSED_THRESHOLD * MAX_GRIPPER_POSITION_RAD;
         }
     }
-    else {
+    else
+    {
         curr_gripper_position_rad = ((-1 * gripper_position_) + MAX_GRIPPER_POSITION_METER) / MAX_GRIPPER_POSITION_METER * MAX_GRIPPER_POSITION_RAD;
     }
 
     auto message = sensor_msgs::msg::JointState();
     message.header.stamp = now();
-    message.name = {"finger_joint"};    
+    message.name = {"finger_joint"};
     message.position = {curr_gripper_position_rad};
     joint_state_publisher_->publish(message);
 }
 
-void GripperNode::update_gripper_state_callback() {
-    if (running_) {
+void GripperNode::update_gripper_state_callback()
+{
+    if (running_)
+    {
         return;
     }
 
     auto message = std_msgs::msg::Bool();
-    if (!fake_hardware_) {
-        message.data = { static_cast<bool>(driver_->is_object_grasped()) };
-    } else {
-        message.data = { false };
+    if (!fake_hardware_)
+    {
+        message.data = {static_cast<bool>(driver_->is_object_grasped())};
+    }
+    else
+    {
+        message.data = {false};
     }
     gripper_state_publisher_->publish(message);
 }
 
 uint8_t GripperNode::decimalToHex(int value)
 {
-  return static_cast<uint8_t>(std::clamp(value, 0, 255));
+    return static_cast<uint8_t>(std::clamp(value, 0, 255));
 }
 
 int GripperNode::convertToGripperSystemPosition(double position)
 {
-    if (position >= 0.015) {
+    if (position >= 0.015)
+    {
         double a = -1399.78;
         double b = -1328.11;
         double c = 218.384;
         return decimalToHex(static_cast<int>(a * pow(position, 2) + b * position + c));
-    } 
+    }
     else if (position >= 0.001)
     {
         double a = 18315;
         double b = -1849.82;
         double c = 223.626;
         return decimalToHex(static_cast<int>(a * pow(position, 2) + b * position + c));
-    } 
+    }
     else
     {
         return decimalToHex(255);
@@ -277,7 +309,8 @@ int GripperNode::convertToGripperSystemPosition(double position)
 // inverse of convertToGripperSystemPosition
 double GripperNode::convertToMillimeters(int value)
 {
-    if (value <= 200) {
+    if (value <= 200)
+    {
         double a = -3.84615e-07;
         double b = -5.67622e-04;
         double c = 0.142692;
@@ -301,8 +334,85 @@ int GripperNode::convertToGripperSystem(double value)
     return decimalToHex(static_cast<int>(value * 255));
 }
 
+void GripperNode::gripper_command_callback(const std_msgs::msg::Float32MultiArray::SharedPtr msg)
+{
+    if (running_)
+    {
+        RCLCPP_WARN(get_logger(), "Ignoring command, gripper is already running an action");
+        return;
+    }
 
-int main(int argc, char ** argv)
+    if (msg->data.size() < 1)
+    {
+        RCLCPP_ERROR(get_logger(), "Received empty command array. Expected at least position data.");
+        return;
+    }
+
+    double position = msg->data[0];
+    double speed = (msg->data.size() > 1) ? msg->data[1] : 0.5; // Default speed 0.5
+    double force = (msg->data.size() > 2) ? msg->data[2] : 0.5; // Default force 0.5
+
+    // Validate inputs
+    if (position < 0 || position > 0.142)
+    {
+        RCLCPP_ERROR(get_logger(), "Invalid position value: %f. Must be between 0 (fully closed) and 0.142 (fully open)", position);
+        return;
+    }
+    if (speed < 0 || speed > 1)
+    {
+        RCLCPP_ERROR(get_logger(), "Invalid speed value: %f. Must be between 0 and 1", speed);
+        return;
+    }
+    if (force < 0 || force > 1)
+    {
+        RCLCPP_ERROR(get_logger(), "Invalid force value: %f. Must be between 0 and 1", force);
+        return;
+    }
+
+    RCLCPP_INFO(get_logger(), "Received gripper command: position=%f, speed=%f, force=%f", position, speed, force);
+
+    running_ = true;
+
+    if (fake_hardware_)
+    {
+        gripper_position_ = position;
+        gripper_speed_ = speed;
+        gripper_force_ = force;
+        RCLCPP_INFO(get_logger(), "[Fake Hardware] Gripper position set to %f", position);
+        running_ = false;
+        return;
+    }
+
+    try
+    {
+        driver_->set_force(convertToGripperSystem(force));
+        driver_->set_speed(convertToGripperSystem(speed));
+        driver_->set_gripper_position(convertToGripperSystemPosition(position));
+
+        auto start_time = std::chrono::steady_clock::now();
+        auto timeout = std::chrono::seconds(action_timeout_);
+        while (std::chrono::steady_clock::now() - start_time < timeout)
+        {
+            if (!driver_->gripper_is_moving())
+            {
+                RCLCPP_INFO(get_logger(), "Gripper movement completed.");
+                running_ = false;
+                return;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+
+        RCLCPP_INFO(get_logger(), "Gripper movement timed out.");
+    }
+    catch (const std::runtime_error &e)
+    {
+        RCLCPP_ERROR(get_logger(), "Error executing command: %s", e.what());
+    }
+
+    running_ = false;
+}
+
+int main(int argc, char **argv)
 {
     rclcpp::init(argc, argv);
     auto node = std::make_shared<GripperNode>();

--- a/robotiq_2f_gripper_hardware/src/robotiq_2f_gripper_node.cpp
+++ b/robotiq_2f_gripper_hardware/src/robotiq_2f_gripper_node.cpp
@@ -83,11 +83,17 @@ GripperNode::GripperNode() : Node("robotiq_2f_gripper_node")
     timer_2_ = create_wall_timer(
         std::chrono::milliseconds(50), std::bind(&GripperNode::update_gripper_state_callback, this));
 
-    // Create subscriber for Float32MultiArray to command the gripper
+    // Create subscriber for confidence-based gripper control with hysteresis
     gripper_command_subscriber_ = create_subscription<std_msgs::msg::Float32MultiArray>(
-        "robotiq_2f_gripper/command", 10,
+        "robotiq_2f_gripper/confidence_command", 10,
         std::bind(&GripperNode::gripper_command_callback, this, _1));
-    RCLCPP_INFO(get_logger(), "Gripper command subscriber created");
+    RCLCPP_INFO(get_logger(), "Gripper confidence command subscriber created");
+
+    // Create subscriber for direct gripper control (binary open/close)
+    gripper_binary_command_subscriber_ = create_subscription<std_msgs::msg::Float32MultiArray>(
+        "robotiq_2f_gripper/binary_command", 10,
+        std::bind(&GripperNode::gripper_binary_command_callback, this, _1));
+    RCLCPP_INFO(get_logger(), "Gripper binary command subscriber created");
 
     RCLCPP_INFO(get_logger(), "Gripper node initialized");
 }
@@ -452,6 +458,91 @@ void GripperNode::gripper_command_callback(const std_msgs::msg::Float32MultiArra
         previous_confidence_ = confidence;
         RCLCPP_DEBUG(get_logger(), "Confidence value %f within hysteresis zone, no action taken", confidence);
     }
+}
+
+void GripperNode::gripper_binary_command_callback(const std_msgs::msg::Float32MultiArray::SharedPtr msg)
+{
+    if (running_)
+    {
+        RCLCPP_WARN(get_logger(), "Ignoring binary command, gripper is already running an action");
+        return;
+    }
+
+    if (msg->data.size() < 1)
+    {
+        RCLCPP_ERROR(get_logger(), "Received empty binary command array. Expected a value.");
+        return;
+    }
+
+    // Get the command value from the message
+    double value = msg->data[0];
+
+    // Validate input value (should be 1.0 for open or -1.0 for close)
+    if (std::abs(std::abs(value) - 1.0) > 0.01)
+    {
+        RCLCPP_ERROR(get_logger(), "Invalid binary command value: %f. Must be 1.0 (open) or -1.0 (close)", value);
+        return;
+    }
+
+    // Default speed and force for the gripper
+    double speed = 0.5; // Default speed 0.5
+    double force = 0.5; // Default force 0.5
+
+    // Calculate gripper position based on binary command
+    double position;
+
+    if (value > 0.0) // Positive value (1.0) means open
+    {
+        position = MAX_GRIPPER_POSITION_METER; // Fully open (0.142m)
+        RCLCPP_INFO(get_logger(), "Binary open command received, opening gripper");
+    }
+    else // Negative value (-1.0) means close
+    {
+        position = 0.0; // Fully closed
+        RCLCPP_INFO(get_logger(), "Binary close command received, closing gripper");
+    }
+
+    RCLCPP_INFO(get_logger(), "Setting gripper position to %f based on binary command %f", position, value);
+
+    running_ = true;
+
+    if (fake_hardware_)
+    {
+        gripper_position_ = position;
+        gripper_speed_ = speed;
+        gripper_force_ = force;
+        RCLCPP_INFO(get_logger(), "[Fake Hardware] Gripper position set to %f", position);
+        running_ = false;
+        return;
+    }
+
+    try
+    {
+        driver_->set_force(convertToGripperSystem(force));
+        driver_->set_speed(convertToGripperSystem(speed));
+        driver_->set_gripper_position(convertToGripperSystemPosition(position));
+
+        auto start_time = std::chrono::steady_clock::now();
+        auto timeout = std::chrono::seconds(action_timeout_);
+        while (std::chrono::steady_clock::now() - start_time < timeout)
+        {
+            if (!driver_->gripper_is_moving())
+            {
+                RCLCPP_INFO(get_logger(), "Gripper movement completed.");
+                running_ = false;
+                return;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+
+        RCLCPP_INFO(get_logger(), "Gripper movement timed out.");
+    }
+    catch (const std::runtime_error &e)
+    {
+        RCLCPP_ERROR(get_logger(), "Error executing binary command: %s", e.what());
+    }
+
+    running_ = false;
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
This is a new feature, that is useful for AI robot models. Instead of interfacing with the gripper via a ROS2 action server. The code now also offers the option to command the gripper via two ROS2 topics (message type: Float32MultiArray, ie. a slice from the output action vector of an AI robot policy). 
- The first topic (/robotiq_2f_gripper/confidence_command) expects a confidence value between -1.0 and 1.0. Positive values correspond to opening the gripper fully, while negative values correspond to closing the gripper fully. There is a hysteresis band from -0.2 to 0.2 in which the gripper holds its current state (to avoid oscillation). 
- If the post-processing of your robot policy includes binning the confidence values, use the second topic (/robotiq_2f_gripper/binary_command) which expects a value out of {-1.0, 1.0} 